### PR TITLE
make the library compile with ghc-7.8.3

### DIFF
--- a/Data/Digest/BCrypt.hsc
+++ b/Data/Digest/BCrypt.hsc
@@ -16,7 +16,7 @@ import Foreign
 import Foreign.C.Types
 import Foreign.C.String
 import qualified Foreign.Ptr ( nullPtr )
-import qualified System.IO.Unsafe ( unsafePerformIO )
+import System.IO.Unsafe ( unsafePerformIO )
 import Data.ByteString.Char8 (split)
 import qualified Data.ByteString.Unsafe as B
 import qualified Data.ByteString.Internal as B ( fromForeignPtr

--- a/haskell-bcrypt.cabal
+++ b/haskell-bcrypt.cabal
@@ -1,5 +1,5 @@
 Name:                haskell-bcrypt
-Version:             0.3.1
+Version:             0.3.2
 Synopsis:            A bcrypt implementation for haskell
 License:             MIT
 License-file:        LICENSE


### PR DESCRIPTION
Th import pulls in the unsafePerformIO function only anyway.
And since it is qualified, ghc 7.8.3 wants it to be called by its full name with its package name as I understand.
Removing "qualified" makes the function callable directly and no complaints are made...
