### PR TITLE
Fix build error

### DIFF
--- a/Data/Digest/BCrypt.hsc
+++ b/Data/Digest/BCrypt.hsc
@@ -16,7 +16,7 @@ import Foreign
 import Foreign.C.Types
 import Foreign.C.String
 import qualified Foreign.Ptr ( nullPtr )
-import qualified System.IO.Unsafe ( unsafePerformIO )
+import           System.IO.Unsafe ( unsafePerformIO )
 import Data.ByteString.Char8 (split)
 import qualified Data.ByteString.Unsafe as B
 import qualified Data.ByteString.Internal as B ( fromForeignPtr


### PR DESCRIPTION
I'm not sure how this ever built. Have I misunderstood something? In version 3.1 I get an error:

```
$ cabal build
Building haskell-bcrypt-0.3.1...
Preprocessing library haskell-bcrypt-0.3.1...
[1 of 1] Compiling Data.Digest.BCrypt ( dist/build/Data/Digest/BCrypt.hs, dist/build/Data/Digest/BCrypt.o )

Data/Digest/BCrypt.hsc:55:22:
    Not in scope: ‘unsafePerformIO’
    Perhaps you meant ‘System.IO.Unsafe.unsafePerformIO’ (imported from System.IO.Unsafe)

Data/Digest/BCrypt.hsc:67:27:
    Not in scope: ‘unsafePerformIO’
    Perhaps you meant ‘System.IO.Unsafe.unsafePerformIO’ (imported from System.IO.Unsafe)
```

This is with cabal-install version 1.22.4.0 and ghc 7.10.1, although I'm not sure how it would ever work with a qualified import...
